### PR TITLE
allow for default of mutable datatypes by passing a type

### DIFF
--- a/openrtb/base.py
+++ b/openrtb/base.py
@@ -13,7 +13,7 @@ class Field(object):
     def __init__(self, datatype, required=False, default=None):
         self.datatype = datatype
         self.required = required
-        self.default = default
+        self.default = default if not callable(default) else default()
         self.name = None
         self.object = None
 


### PR DESCRIPTION
Currently the field does not support a default of [] for the same reason you can't have mutable types as defaults in keyword arguments.

This diff allows for a type like `list` or `dict` to be passed in to construct a new instance of the mutable datatype.