### PR TITLE
Fix String() for Python 3

### DIFF
--- a/openrtb/base.py
+++ b/openrtb/base.py
@@ -40,29 +40,13 @@ class Field(object):
 
         return v
 
-if six.PY2:
-    def String(value):
-        if isinstance(value, six.text_type):
-            return value
-        elif isinstance(value, six.binary_type):
-            return value.decode('utf-8', errors='ignore')
-        else:
-            value = str(value)
 
-        return six.u(value)
-
-elif six.PY3:
-    def String(value):
-        if not isinstance(value, str):
-            value = str(value)
-
-        try:
-            return codecs.decode(six.b(value), 'utf-8', errors="ignore")
-        except UnicodeEncodeError:
-            return value
-
-else:
-    assert False, "Your python version is not supported, sorry"
+def String(value, encoding='utf-8', errors='ignore'):
+    if isinstance(value, six.text_type):
+        return value
+    if isinstance(value, six.binary_type):
+        return value.decode(encoding=encoding, errors=errors)
+    return six.text_type(value)
 
 
 class ObjectMeta(type):

--- a/openrtb/base.py
+++ b/openrtb/base.py
@@ -1,12 +1,4 @@
 import six
-import codecs
-import sys
-
-print(sys.version)
-
-
-class InvalidConstant(Exception):
-    pass
 
 
 class ValidationError(Exception):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -100,13 +100,13 @@ class TestFields(unittest.TestCase):
         self.assertEqual(openrtb.base.String(u'uni'), u'uni')
 
     def test_ascii(self):
-        self.assertEqual(openrtb.base.String('uni'), u'uni')
+        self.assertEqual(openrtb.base.String(b'uni'), u'uni')
 
     def test_utf8(self):
-        self.assertEqual(openrtb.base.String('утф'), u'утф')
+        self.assertEqual(openrtb.base.String(u'утф'.encode('utf-8')), u'утф')
 
     def test_bad_utf8(self):
-        self.assertEqual(openrtb.base.String('x\xff'), u'x')
+        self.assertEqual(openrtb.base.String(b'x\xff'), u'x')
 
     def test_convert_to_unicode(self):
         self.assertEqual(openrtb.base.String(1), u'1')


### PR DESCRIPTION
This PR fixes `String()` for Python 3 and simplifies it.